### PR TITLE
Validate invoice which is not XML

### DIFF
--- a/core/actors/Exchange.php
+++ b/core/actors/Exchange.php
@@ -346,8 +346,8 @@ XML;
     private static function validateInvoice($xmlString)
     {
         $xml = new \DOMDocument();
-        $xml->loadXML($xmlString, LIBXML_NOBLANKS);
         try {
+            $xml->loadXML($xmlString, LIBXML_NOBLANKS);
             $schema = SAFEROOT.'core/schemas/Schema_del_file_xml_FatturaPA_versione_1.2_cleanup.xsd';
             $valid = $xml->schemaValidate($schema);
         } catch (\Exception $e) {


### PR DESCRIPTION
When I add a file which is not an XML, I try to validate this file and I get an exception because it's not a valid XML.