### PR TITLE
close issue 53 - key length in channels table for mysql must be defined

### DIFF
--- a/core/db/migrations/20180923120240_create_channels_table.php
+++ b/core/db/migrations/20180923120240_create_channels_table.php
@@ -15,7 +15,7 @@ class CreateChannelsTable extends MigrationManager
             $this->schema->create('channels', function (Illuminate\Database\Schema\Blueprint $table) {
                 $table->text('cedente');
                 $table->text('issuer');
-                $table->primary('cedente');
+                $table->primary([DB::raw('cedente(191)')]);
             });
         }
     }


### PR DESCRIPTION
mysql needs key length when applied to text/blob fields