### PR TITLE
Hotfix/issue 57 fix php artisan error

### DIFF
--- a/core/actors/Base.php
+++ b/core/actors/Base.php
@@ -120,7 +120,7 @@ class Base
 
         $actors = self::getActors();
         if (!in_array($actor, $actors)) {
-            abort(404);
+            abort(404, "Invalid actor: $actor");
         }
                 
         return $actor;

--- a/core/actors/Base.php
+++ b/core/actors/Base.php
@@ -110,8 +110,12 @@ class Base
         if (class_exists('\URL')) {
             // we're inside Laravel: URL is defined in rpc/config/app.php
             $url = \URL::current();
-            $urlData = explode("/", $url);
-            $actor = @$urlData[3];
+            if (PHP_SAPI == 'cli') {
+                $actor = "sdi"; // Quick hotfix, should be configurable
+            } else {
+                $urlData = explode("/", $url);
+                $actor = @$urlData[3];
+            }
         } else {
             $url = $_SERVER['REQUEST_URI'];
             $urlData = explode("/", $url);


### PR DESCRIPTION
Quick hotfix to remove the  [Symfony\Component\HttpKernel\Exception\NotFoundHttpException] error during any php artisan command (#57)

This error occurred during the installation with composer considering these commands are executed:
@php artisan key:generate
@php artisan package:discover